### PR TITLE
Fixed bug with common prefix of options

### DIFF
--- a/include/CompilerOptions.h
+++ b/include/CompilerOptions.h
@@ -54,12 +54,23 @@ struct CompilerOptions {
 
     std::string GetOptionValue(const std::string& option) const
     {
-        auto s = option.size();
         for (auto i = 0; i < options.size(); ++i) {
-            auto& op = options[i];
-            if (op.compare(0, s, option) == 0) {
-                return op[s] == '=' ? op.substr(s + 1) : (++i != options.size() ? options[i] : "");
+            auto delimiterPtr = options[i].find('=');
+            auto opName = options[i].substr(0, delimiterPtr);
+            if (opName != option) {
+                continue;
             }
+            std::string opValue = "";
+            if (delimiterPtr != std::string::npos) {
+                opValue = options[i].substr(delimiterPtr+1, std::string::npos);
+            }
+            if (!opValue.empty()) {
+                return opValue;
+            }
+            if (i < options.size()) {
+                return options[i + 1];
+            }
+            return "";
         }
         return "";
     }


### PR DESCRIPTION
Now, if you pass the `-stdlib=libstdc++` option to `--compile-options`, then calling `compilerOptions.GetOptionValue("-std") ` will return an incorrect result. This is because the current version of `GetOptionValue` looks for any option that starts with the "-std" prefix instead of a full string comparison.